### PR TITLE
chore: run tests through npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-connect": "~0.3.0"
   },
   "scripts": {
-    "test": "./node_modules/gulp/bin/gulp.js test"
+    "test": "karma start --single-run"
   },
   "author": "Vojta Jína <vojta.jina@gmail.com>",
   "license": "Apache-2.0"


### PR DESCRIPTION
This PR is more a question about different ways of running tests (although merging this one wouldn't hurt for now). It looks like migration from Grunt to gulp made the `gulp test` task disappear. Not sure what is the strategy here but I would love to be able to type 'gulp'  (or `gulp build`) to execute all the build steps with test. 

Would be happy to craft a PR based on your input!
