### PR TITLE
feat: use Makefile for npm test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - SAUCE_USERNAME=angular-ci
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
+    - TRAVIS_BROWSERS=SL_Chrome
 
 install:
   - npm install
@@ -16,6 +17,6 @@ install:
 before_script:
 
 script:
-  - karma start --single-run --browsers SL_Chrome --reporters dots
+  - make test
 
 after_script:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+ifndef TRAVIS_BROWSERS
+	TRAVIS_BROWSERS=Chrome
+endif
+
+test:
+	karma start --single-run --browsers $(TRAVIS_BROWSERS)
+	node example/node/test/main.test.js
+
+.PHONY : test

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "through2": "~0.4.1"
   },
   "scripts": {
-    "test": "karma start --single-run"
+    "test": "make test"
   },
   "author": "Vojta Jína <vojta.jina@gmail.com>",
   "license": "Apache-2.0"


### PR DESCRIPTION
calls out to karma + node test. Also configured to work with travis +
npm test command.  From suggestion in #33.

Open to other ideas on this. Perhaps there's a better way to send down the browser config to karma? Or maybe we could just put the node command into `.travis.yml` directly? The goal here was to unify the test runs though.
