### PR TITLE
Overriding dependencies in child injectors

### DIFF
--- a/src/injector.js
+++ b/src/injector.js
@@ -111,7 +111,7 @@ class Injector {
 
 
   // Return an instance for given token.
-  get(token, resolving = [], wantPromise = false, wantLazy = false) {
+  get(token, resolving = [], wantPromise = false, wantLazy = false, originalInjector = this) {
     var resolvingMsg = '';
     var instance;
     var injector = this;
@@ -154,7 +154,7 @@ class Injector {
           lazyInjector = injector.createChild(locals);
         }
 
-        return lazyInjector.get(token, resolving, wantPromise, false);
+        return lazyInjector.get(token, resolving, wantPromise, false, lazyInjector);
       };
     }
 
@@ -190,7 +190,7 @@ class Injector {
         throw new Error(`No provider for ${toString(token)}!${resolvingMsg}`);
       }
 
-      return this.parent.get(token, resolving, wantPromise, wantLazy);
+      return this.parent.get(token, resolving, wantPromise, wantLazy, originalInjector);
     }
 
     if (resolving.indexOf(token) !== -1) {
@@ -212,10 +212,10 @@ class Injector {
     var args = provider.params.map((param) => {
 
       if (delayingInstantiation) {
-        return this.get(param.token, resolving, true, param.isLazy);
+        return originalInjector.get(param.token, resolving, true, param.isLazy, originalInjector);
       }
 
-      return this.get(param.token, resolving, param.isPromise, param.isLazy);
+      return originalInjector.get(param.token, resolving, param.isPromise, param.isLazy, originalInjector);
     });
 
     // Delaying the instantiation - return a promise.


### PR DESCRIPTION
Consider the situation where a service, `A`, is defined in a `parent` injector but has a dependency on another service, `B`, which is provided in both the `parent` injector and a `child` injector, say as `parentB` and `childB` respectively.

If you get an instance of `A` from the `parent` then you should get `A(parentB)` but if you get the instance from the `child` injector then you want to get `A(childB)`.

This pull request implements this ability by passing through an `originalInjector` (it could be named something else such as `invokedInjector`), which is passes along whenever the injector looks for a dependency in its parent, so that the original injector is used to find parameter dependencies on any services it provides.

Partially closes #37

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/di.js/38)

<!-- Reviewable:end -->
