### PR TITLE
full path for git repos in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "url": "https://github.com/angular/di.js/issues"
   },
   "dependencies": {
-    "traceur": "vojtajina/traceur-compiler#add-es6-pure-transformer-dist",
+    "traceur": "git://github.com/vojtajina/traceur-compiler#add-es6-pure-transformer-dist",
     "es6-shim": "~0.9.2"
   },
   "devDependencies": {
-    "rtts-assert": "angular/assert",
+    "rtts-assert": "git://github.com/angular/assert",
     "gulp": "^3.5.6",
     "gulp-connect": "~1.0.5",
-    "gulp-traceur": "vojtajina/gulp-traceur#traceur-as-peer",
-    "gulp-git": "vojtajina/gulp-git#hacked",
+    "gulp-traceur": "git://github.com/vojtajina/gulp-traceur#traceur-as-peer",
+    "gulp-git": "git://github.com/vojtajina/gulp-git#hacked",
     "karma": "^0.12.1",
     "karma-script-launcher": "~0.1.0",
     "karma-chrome-launcher": "~0.1.2",
@@ -29,8 +29,8 @@
     "karma-sauce-launcher": "~0.2.4",
     "karma-jasmine": "^0.2.2",
     "karma-requirejs": "^0.2.1",
-    "karma-traceur-preprocessor": "vojtajina/karma-traceur-preprocessor#traceur-as-peer",
-    "pipe": "angular/pipe#remove-transitive-deps",
+    "karma-traceur-preprocessor": "git://github.com/vojtajina/karma-traceur-preprocessor#traceur-as-peer",
+    "pipe": "git://github.com/angular/pipe#remove-transitive-deps",
     "requirejs": "2.1.10",
     "through2": "~0.4.1"
   },


### PR DESCRIPTION
Uses full paths to make it easier for other folks to use Vojta's repos...otherwise 'npm install' can fail.
