### PR TITLE
feat: inject non-annotated tokens as values

### DIFF
--- a/example/coffee/electric_heater.js
+++ b/example/coffee/electric_heater.js
@@ -1,7 +1,8 @@
-import {Provide} from 'di';
+import {Inject, Provide} from 'di';
 
 import {Heater} from './heater';
 
+@Inject()
 @Provide(Heater)
 export class ElectricHeater {
   constructor() {}

--- a/example/coffee/mock_heater.js
+++ b/example/coffee/mock_heater.js
@@ -1,7 +1,8 @@
-import {Provide} from 'di';
+import {Inject, Provide} from 'di';
 
 import {Heater} from './heater';
 
+@Inject()
 @Provide(Heater)
 export class MockHeater {
   on() {}

--- a/example/kitchen-di/electricity.js
+++ b/example/kitchen-di/electricity.js
@@ -1,2 +1,4 @@
+import {Inject} from 'di';
 
+@Inject
 export class Electricity {}

--- a/example/kitchen-di/mock_heater.js
+++ b/example/kitchen-di/mock_heater.js
@@ -1,6 +1,8 @@
-import {Provide} from 'di';
+import {Inject, Provide} from 'di';
 import {Heater} from './coffee_maker/heater';
 
+
+@Inject
 @Provide(Heater)
 export class MockHeater {
   constructor() {}

--- a/example/kitchen-di/skillet.js
+++ b/example/kitchen-di/skillet.js
@@ -1,4 +1,7 @@
+import {Inject} from 'di';
 
+
+@Inject
 export class Skillet {
   constructor() {}
 

--- a/src/annotations.js
+++ b/src/annotations.js
@@ -82,6 +82,23 @@ function hasAnnotation(fn, annotationClass) {
 }
 
 
+function hasParameterAnnotation(fn, AnnotationClass) {
+  if (!fn.parameters || fn.parameters.length === 0) {
+    return false;
+  }
+
+  for (var parameterAnnotations of fn.parameters) {
+    for (var annotation of parameterAnnotations) {
+      if (annotation instanceof AnnotationClass) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+
 // Read annotations on a function or class and collect "interesting" metadata:
 function readAnnotations(fn) {
   var collectedAnnotations = {
@@ -143,6 +160,7 @@ function readAnnotations(fn) {
 export {
   annotate,
   hasAnnotation,
+  hasParameterAnnotation,
   readAnnotations,
 
   SuperConstructor,

--- a/src/providers.js
+++ b/src/providers.js
@@ -127,10 +127,32 @@ class FactoryProvider {
 }
 
 
+// ValueProvider knows how to return values.
+//
+// This is a trivial provider that just always returns the same value,
+// without requiring any arguments.
+class ValueProvider {
+  constructor(value) {
+    this.provider = function() {};
+    this.params = [];
+    this.isPromise = false;
+    this._value = value;
+  }
+
+  create() {
+    return this._value;
+  }
+}
+
+
 export function createProviderFromFnOrClass(fnOrClass, annotations) {
   if (isClass(fnOrClass)) {
     return new ClassProvider(fnOrClass, annotations.params, annotations.provide.isPromise);
   }
 
   return new FactoryProvider(fnOrClass, annotations.params, annotations.provide.isPromise);
+}
+
+export function createProviderFromValue(value) {
+  return new ValueProvider(value);
 }

--- a/test/annotations.spec.js
+++ b/test/annotations.spec.js
@@ -1,5 +1,6 @@
 import {
   hasAnnotation,
+  hasParameterAnnotation,
   readAnnotations,
   Inject,
   InjectLazy,
@@ -39,6 +40,28 @@ describe('hasAnnotation', function() {
     function foo() {}
 
     expect(hasAnnotation(foo, NopeAnnotation)).toBe(false);
+  });
+});
+
+
+describe('hasParameterAnnotation', function() {
+
+  it('should return false if no annotation', function() {
+    class FooAnnotation {}
+
+    function nothing() {}
+
+    expect(hasParameterAnnotation(nothing, FooAnnotation)).toBe(false);
+  });
+
+
+  it('should return if at least one parameter has specific annotation', function() {
+    class FooAnnotation {}
+    class BarType {}
+
+    function nothing(one: BarType, @FooAnnotation two: BarType) {}
+
+    expect(hasParameterAnnotation(nothing, FooAnnotation)).toBe(true);
   });
 });
 

--- a/test/async.spec.js
+++ b/test/async.spec.js
@@ -5,11 +5,13 @@ import {Injector} from '../src/injector';
 class UserList {}
 
 // An async provider.
+@Inject
 @ProvidePromise(UserList)
 function fetchUsers() {
   return Promise.resolve(new UserList);
 }
 
+@Inject
 class SynchronousUserList {}
 
 class UserController {

--- a/test/fixtures/car.js
+++ b/test/fixtures/car.js
@@ -23,6 +23,8 @@ export class CyclicEngine {
 // @Inject(Engine)
 annotate(Car, new Inject(Engine));
 
+// @Inject
+annotate(createEngine, new Inject());
 // @Provide(Engine)
 annotate(createEngine, new Provide(Engine));
 

--- a/test/injector.spec.js
+++ b/test/injector.spec.js
@@ -9,6 +9,7 @@ import {module as shinyHouseModule} from './fixtures/shiny_house';
 describe('injector', function() {
 
   it('should instantiate a class without dependencies', function() {
+    @Inject
     class Car {
       constructor() {}
       start() {}
@@ -22,6 +23,7 @@ describe('injector', function() {
 
 
   it('should resolve dependencies based on @Inject annotation', function() {
+    @Inject
     class Engine {
       start() {}
     }
@@ -57,6 +59,7 @@ describe('injector', function() {
       start() {}
     }
 
+    @Inject
     @Provide(Engine)
     class MockEngine {
       start() {}
@@ -73,6 +76,7 @@ describe('injector', function() {
   it('should allow factory function', function() {
     class Size {}
 
+    @Inject
     @Provide(Size)
     function computeSize() {
       return 0;
@@ -86,10 +90,12 @@ describe('injector', function() {
 
 
   it('should use type annotations when available', function() {
+    @Inject
     class Engine {
       start() {}
     }
 
+    @Inject
     class Car {
       constructor(e: Engine) {
         this.engine = e;
@@ -110,6 +116,7 @@ describe('injector', function() {
       start() {}
     }
 
+    @Inject
     class MockEngine extends Engine {
       start() {}
     }
@@ -131,14 +138,17 @@ describe('injector', function() {
 
 
   it('should use mixed @Inject with type annotations', function() {
+    @Inject
     class Engine {
       start() {}
     }
 
+    @Inject
     class Bumper {
       start() {}
     }
 
+    @Inject
     class Car {
       constructor(e: Engine, @Inject(Bumper) b) {
         this.engine = e;
@@ -157,6 +167,7 @@ describe('injector', function() {
 
 
   it('should cache instances', function() {
+    @Inject
     class Car {
       constructor() {}
       start() {}
@@ -194,6 +205,7 @@ describe('injector', function() {
 
 
   it('should show the full path when error happens in a constructor', function() {
+    @Inject
     class Engine {
       constructor() {
         throw new Error('This engine is broken!');
@@ -213,6 +225,7 @@ describe('injector', function() {
 
 
   it('should support "super" to call a parent constructor', function() {
+    @Inject
     class Something {}
 
     class Parent {
@@ -240,7 +253,10 @@ describe('injector', function() {
 
 
   it('should support "super" to call multiple parent constructors', function() {
+    @Inject
     class Foo {}
+
+    @Inject
     class Bar {}
 
     class Parent {
@@ -345,9 +361,51 @@ describe('injector', function() {
   });
 
 
+  describe('default providers', function() {
+
+    it('should inject the value for object tokens', function() {
+      var foo = {
+        bar: true
+      };
+
+      @Inject(foo)
+      class Bar {
+        constructor(foo) {
+          this.foo = foo;
+        }
+      }
+
+      var injector = new Injector();
+      var bar = injector.get(Bar);
+
+      expect(bar.foo).toBe(foo);
+    });
+
+
+    it('should inject the value for non-annotated functions', function() {
+      var fs = {
+        readFile: function() {}
+      };
+
+      @Inject(fs.readFile)
+      class Foo {
+        constructor(readFile) {
+          this.readFile = readFile;
+        }
+      }
+
+      var injector = new Injector();
+      var foo = injector.get(Foo);
+
+      expect(foo.readFile).toBe(fs.readFile);
+    });
+  });
+
+
   describe('transient', function() {
     it('should never cache', function() {
       @TransientScope
+      @Inject
       class Foo {}
 
       var injector = new Injector();
@@ -359,6 +417,7 @@ describe('injector', function() {
   describe('child', function() {
 
     it('should load instances from parent injector', function() {
+      @Inject
       class Car {
         start() {}
       }
@@ -374,6 +433,7 @@ describe('injector', function() {
 
 
     it('should create new instance in a child injector', function() {
+      @Inject
       class Car {
         start() {}
       }
@@ -397,6 +457,7 @@ describe('injector', function() {
     it('should force new instances by annotation', function() {
       class RouteScope {}
 
+      @Inject
       class Engine {
         start() {}
       }
@@ -425,10 +486,12 @@ describe('injector', function() {
     it('should force new instances by annotation using overriden provider', function() {
       class RouteScope {}
 
+      @Inject
       class Engine {
         start() {}
       }
 
+      @Inject
       @RouteScope
       @Provide(Engine)
       class MockEngine {
@@ -451,12 +514,14 @@ describe('injector', function() {
     it('should force new instance by annotation using the lowest overriden provider', function() {
       class RouteScope {}
 
+      @Inject
       @RouteScope
       class Engine {
         constructor() {}
         start() {}
       }
 
+      @Inject
       @RouteScope
       @Provide(Engine)
       class MockEngine {
@@ -464,6 +529,7 @@ describe('injector', function() {
         start() {}
       }
 
+      @Inject
       @RouteScope
       @Provide(Engine)
       class DoubleMockEngine {
@@ -508,6 +574,7 @@ describe('injector', function() {
     it('should instantiate lazily', function() {
       var constructorSpy = jasmine.createSpy('constructor');
 
+      @Inject
       class ExpensiveEngine {
         constructor() {
           constructorSpy();
@@ -540,6 +607,7 @@ describe('injector', function() {
     it('should instantiate lazily from a parent injector', function() {
       var constructorSpy = jasmine.createSpy('constructor');
 
+      @Inject
       class ExpensiveEngine {
         constructor() {
           constructorSpy();


### PR DESCRIPTION
If a token is an object or a non-annotated function/class and there is no other provider defined for this token, the default provider returns the value instead of calling it.

This is helpful for injecting third-party code (without instantiating it) that is not annotated. Eg. Node's native modules:

``` js
var fs = require('fs');

@Inject(fs.readFile)
class Foo {
  constuctor(readFile) {}
}
```

Fixes #30

BREAKING CHANGE:
This means that every function/class (that should be called/instantiated) has to be annotated with `@Inject`, even if it takes no arguments.

---

See how templating and expressionist needs to be refactored:
https://github.com/angular/templating/pull/35
https://github.com/angular/expressionist.js/pull/13

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/di.js/45)

<!-- Reviewable:end -->
