### PR TITLE
chore(package.json): use traceur#0.0.33 until dependencies can cope with 0.0.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/angular/di.js/issues"
   },
   "dependencies": {
-    "traceur": "~0.0.33",
+    "traceur": "0.0.33",
     "es6-shim": "~0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #70
