### PR TITLE
Invalid assumption of a class to be a factory

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -7,11 +7,12 @@ function isUpperCase(char) {
 
 
 function isClass(clsOrFunction) {
-  if (clsOrFunction.name) {
+  if (Object.keys(clsOrFunction.prototype).length > 0){
+    return true;
+  }else if (clsOrFunction.name) {
     return isUpperCase(clsOrFunction.name.charAt(0));
   }
-
-  return Object.keys(clsOrFunction.prototype).length > 0;
+  return false;
 }
 
 


### PR DESCRIPTION
**Overview**
Uglify converts all class names to single letter lower case ones the factory provider automatically get created instead of the class provider. This should help rectify it.

**Reproducable:** always
**Browsers**: Chrome 39.0.2171.95
**Operating System:** OS X
**Steps to reproduce**
- Create two classes inside a closure

``` js
(function () {
    var di = require('di');

    function Apples(b) {
        this.bapples = b;
    }

    Apples.prototype.print = function () {
        console.log(this.bapples.getMyName());
    };

    function Bapples() {}
    Bapples.prototype.getMyName = function () {
        return 'My Name is TUshar';
    };

    di.annotate(Apples, new di.Inject(Bapples));

    injector = new di.Injector();
    a = injector.get(Apples);
    a.print();
})();
```
- run the code - works perfectly fine
- minify the source

``` js
! function () {
    var e = require("di"),
        Injector = e.Injector;

    function t() {
        // this.bapples = t
    }
    injector = new Injector();
    a = injector.get(t);
    a.print();
}();
```
- run the code (minified version), throws the following error -

``` bash
    a.print();
      ^
TypeError: Cannot call method 'print' of undefined
    at /Users/tusharmathur/Documents/Projects/Executables/JavaScript.min.js:11:4
    at Object.<anonymous> (/Users/tusharmathur/Documents/Projects/Executables/JavaScript.min.js:12:2)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:929:3
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/di.js/93)

<!-- Reviewable:end -->
