### PR TITLE
this is always undefined in strict mode

### DIFF
--- a/src/annotations.js
+++ b/src/annotations.js
@@ -26,6 +26,7 @@ class Inject {
 
 class InjectPromise extends Inject {
   constructor(...tokens) {
+    super(tokens);
     this.tokens = tokens;
     this.isPromise = true;
     this.isLazy = false;
@@ -34,6 +35,7 @@ class InjectPromise extends Inject {
 
 class InjectLazy extends Inject {
   constructor(...tokens) {
+    super(tokens);
     this.tokens = tokens;
     this.isPromise = false;
     this.isLazy = true;
@@ -49,6 +51,7 @@ class Provide {
 
 class ProvidePromise extends Provide {
   constructor(token) {
+    super(token);
     this.token = token;
     this.isPromise = true;
   }

--- a/src/util.js
+++ b/src/util.js
@@ -14,7 +14,7 @@ function isObject(value) {
 }
 
 
-function toString(token) {
+function tokenToString(token) {
   if (typeof token === 'string') {
     return token;
   }

--- a/src/util.js
+++ b/src/util.js
@@ -30,11 +30,11 @@ function toString(token) {
   return token.toString();
 }
 
-var ownKeys = (this.Reflect && Reflect.ownKeys ? Reflect.ownKeys : function ownKeys(O) {
+function ownKeys(O) {
   var keys = Object.getOwnPropertyNames(O);
   if (Object.getOwnPropertySymbols) return keys.concat(Object.getOwnPropertySymbols(O));
   return keys;
-});
+}
 
 
 export {


### PR DESCRIPTION
If we're in a strict mode, then ```this``` will be undefined. Thus, it is easier just to use in-place implementation. Instead of trying to mess with ```global``` and ```window```. Strict mode happens, for example, when we translate this code to use with system.js