### PR TITLE
Added super() as first call when extend

### DIFF
--- a/src/annotations.js
+++ b/src/annotations.js
@@ -26,6 +26,7 @@ class Inject {
 
 class InjectPromise extends Inject {
   constructor(...tokens) {
+    super();
     this.tokens = tokens;
     this.isPromise = true;
     this.isLazy = false;
@@ -34,6 +35,7 @@ class InjectPromise extends Inject {
 
 class InjectLazy extends Inject {
   constructor(...tokens) {
+    super();
     this.tokens = tokens;
     this.isPromise = false;
     this.isLazy = true;
@@ -49,6 +51,7 @@ class Provide {
 
 class ProvidePromise extends Provide {
   constructor(token) {
+    super();
     this.token = token;
     this.isPromise = true;
   }


### PR DESCRIPTION
Trying to use `babel --stage 0` to compile `src` gives error because `super()` not called as first thing in some constructor functions that extend other classes.

```
➜  di.js git:(master) babel --stage 0 src
/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/transformation/file/index.js:604
      throw err;
            ^
SyntaxError: src/annotations.js: Line 29: 'this' is not allowed before super()
  27 | class InjectPromise extends Inject {
  28 |   constructor(...tokens) {
> 29 |     this.tokens = tokens;
     |     ^
  30 |     this.isPromise = true;
  31 |     this.isLazy = false;
  32 |   }
    at TraversalPath.errorWithNode (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/path/index.js:449:15)
    at TraversalPath.enter (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/transformation/transformers/es6/classes.js:138:20)
    at TraversalPath.call (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/path/index.js:740:28)
    at TraversalPath.visit (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/path/index.js:764:10)
    at TraversalContext.visitSingle (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/context.js:72:41)
    at TraversalContext.visit (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/context.js:82:19)
    at Function.traverse.node (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/index.js:59:17)
    at TraversalPath.visit (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/path/index.js:781:31)
    at TraversalContext.visitSingle (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/context.js:72:41)
    at TraversalContext.visit (/Users/dmtrs/.nvm/versions/io.js/v2.0.1/lib/node_modules/babel/node_modules/babel-core/lib/babel/traversal/context.js:82:19)
```